### PR TITLE
Change url to Loggly Gen2, adding support to Tags, Exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a plugin for [Logstash](https://github.com/elasticsearch/logstash).
 
+Custom logstash plugin to send logs to Loggly. Check out Loggly's [Logstash logging documentation](https://www.loggly.com/docs/logstash-logs/) to learn more.
+
 It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
 
 ## Documentation

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -4,18 +4,18 @@ require "logstash/namespace"
 require "uri"
 # TODO(sissel): Move to something that performs better than net/http
 require "net/http"
-require "net/https"
+require "net/https"	
 
 
 # Ugly monkey patch to get around http://jira.codehaus.org/browse/JRUBY-5529
 Net::BufferedIO.class_eval do
-    BUFSIZE = 1024 * 16
-
-    def rbuf_fill
-      timeout(@read_timeout) {
-        @rbuf << @io.sysread(BUFSIZE)
-      }
-    end
+  BUFSIZE = 1024 * 16
+  
+  def rbuf_fill
+    timeout(@read_timeout) {
+      @rbuf << @io.sysread(BUFSIZE)
+    }
+  end
 end
 
 # Got a loggly account? Use logstash to ship logs to Loggly!
@@ -29,9 +29,9 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   config_name "loggly"
 
   # The hostname to send logs to. This should target the loggly http input
-  # server which is usually "logs.loggly.com"
-  config :host, :validate => :string, :default => "logs.loggly.com"
-
+  # server which is usually "logs-01.loggly.com" (Gen2 account)
+  config :host, :validate => :string, :default => "logs-01.loggly.com"
+  
   # The loggly http input key to send to.
   # This is usually visible in the Loggly 'Inputs' page as something like this:
   # ....
@@ -43,52 +43,73 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   # the event. This is mainly aimed at multitenant hosting providers who want
   # to offer shipping a customer's logs to that customer's loggly account.
   config :key, :validate => :string, :required => true
-
+  
   # Should the log action be sent over https instead of plain http
   config :proto, :validate => :string, :default => "http"
-
+  
+  # Loggly Tag
+  # Tag helps you to find your logs in the Loggly dashboard easily
+  # You can make a search in Loggly using tag as "tag:logstash-contrib"
+  # or the tag set by you in the config file.
+  #
+  # You can use %{somefield} to allow for custom tag values.
+  # Helpful for leveraging Loggly source groups.
+  # https://www.loggly.com/docs/source-groups/
+  config :tag, :validate => :string, :default => "logstash"
+  
   # Proxy Host
   config :proxy_host, :validate => :string
-
+  
   # Proxy Port
   config :proxy_port, :validate => :number
-
+  
   # Proxy Username
   config :proxy_user, :validate => :string
-
+  
   # Proxy Password
   config :proxy_password, :validate => :password, :default => ""
-
-
+  
+  
   public
   def register
     # nothing to do
   end
-
+  
   public
   def receive(event)
-    return unless output?(event)
-
-    if event == LogStash::SHUTDOWN
-      finished
-      return
-    end
-
-    # Send the event over http.
-    url = URI.parse("#{@proto}://#{@host}/inputs/#{event.sprintf(@key)}")
-    @logger.info("Loggly URL", :url => url)
-    http = Net::HTTP::Proxy(@proxy_host, @proxy_port, @proxy_user, @proxy_password.value).new(url.host, url.port)
-    if url.scheme == 'https'
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    end
-    request = Net::HTTP::Post.new(url.path)
-    request.body = event.to_json
-    response = http.request(request)
-    if response.is_a?(Net::HTTPSuccess)
-      @logger.info("Event send to Loggly OK!")
-    else
-      @logger.warn("HTTP error", :error => response.error!)
-    end
+    5.times do #retries up to five times
+      begin
+        return unless output?(event)
+        
+        if event == LogStash::SHUTDOWN
+          finished
+          return
+        end
+        
+        # Send the event over http.
+        url = URI.parse("#{@proto}://#{@host}/inputs/#{event.sprintf(@key)}/tag/#{event.sprintf(@tag)}")
+        @logger.info("Loggly URL", :url => url)
+        http = Net::HTTP::Proxy(@proxy_host, @proxy_port, @proxy_user, @proxy_password.value).new(url.host, url.port)
+        if url.scheme == 'https'
+          http.use_ssl = true
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        end
+        
+        request = Net::HTTP::Post.new(url.path)
+        request.body = event.to_json
+        response = http.request(request)
+        
+        if response.is_a?(Net::HTTPSuccess)
+          @logger.info("Event send to Loggly OK!")
+          break
+        else
+          @logger.warn("HTTP error", :error => response.error!)
+        end
+      rescue Exception => e
+        @logger.error(e.backtrace.inspect)
+        puts e.message
+        puts e.backtrace.inspect
+      end # rescue
+    end # loop
   end # def receive
 end # class LogStash::Outputs::Loggly


### PR DESCRIPTION
Deleted old repository due to lots of conflicts. Merged all the changes in the new branch. 

Changes include

<ol>
<li>Updated README to add a link to Loggly docs</li>
<li>Updated Loggly url to Gen2 account</li>
<li>Added support for tags</li>
<li>Supports dynamic tag values. thanks @nywilken</li>
<li>Added Exception Handling</li>
<li>Retires up to five times</li>
</ol>
